### PR TITLE
An LLM tokenizer implemented as a streamly application

### DIFF
--- a/examples/BytePairEncoder.hs
+++ b/examples/BytePairEncoder.hs
@@ -1,0 +1,53 @@
+-- To run this program:
+--
+-- cabal run --flag fusion-plugin BytePairEncoder test-data.txt
+--
+module BytePairEncoder (main) where
+
+import Data.Function ((&))
+import qualified Data.Map as M
+import GHC.Word (Word8)
+import qualified Streamly.Data.Fold as Fold
+import qualified Streamly.Data.Stream as Stream
+import qualified Streamly.FileSystem.File as File
+import System.Environment (getArgs)
+
+-------------------------------------------------------------------------------
+-- Byte indexing and text representation
+-------------------------------------------------------------------------------
+
+-- Stores byte-to-index mapping and index-to-text mapping
+data ByteMappings = ByteMappings
+  { byteToIndex :: !(M.Map Word8 Int), -- Maps bytes to unique indices
+    indexToText :: !(M.Map Int String) -- Maps indices to text representation
+  }
+  deriving (Show)
+
+{-# INLINE assignIndex #-}
+assignIndex :: ByteMappings -> Word8 -> ByteMappings
+assignIndex (ByteMappings b2i i2t) byte =
+  case M.lookup byte b2i of
+    Just _ -> ByteMappings b2i i2t -- byte already indexed
+    Nothing ->
+      let nextIndex = M.size b2i -- next available index
+          byteText = [toEnum (fromIntegral byte) :: Char] -- convert byte to ASCII char
+       in ByteMappings
+            (M.insert byte nextIndex b2i)
+            (M.insert nextIndex byteText i2t)
+
+indexBytes :: String -> IO ByteMappings
+indexBytes file =
+  File.read file -- Stream IO Word8
+    & Stream.fold (Fold.foldl' assignIndex initialMappings) -- IO ByteMappings
+  where
+    initialMappings = ByteMappings M.empty M.empty
+
+-------------------------------------------------------------------------------
+-- Main
+-------------------------------------------------------------------------------
+
+main :: IO ()
+main = do
+  name <- fmap head getArgs
+  mappings <- indexBytes name
+  print mappings -- Print both mappings

--- a/examples/BytePairEncoder.hs
+++ b/examples/BytePairEncoder.hs
@@ -195,6 +195,14 @@ greedyTokenizer mapping = Pipe consume produce (V.empty, "", 0)
 -- Main
 -------------------------------------------------------------------------------
 
+-- | Main entry point
+--
+-- Usage:
+--
+-- cabal run --flag fusion-plugin BytePairEncoder <input-file-path>
+--
+-- This will read the test data from test-data.txt, build the ByteMappings,
+-- from frequent byte pairs in the file, and then tokenize the data to stdout.
 main :: IO ()
 main = do
   name <- fmap head getArgs

--- a/hie.yaml
+++ b/hie.yaml
@@ -62,6 +62,8 @@ cradle:
               component: "exe:WordServer"
             - path: "./examples/WordFrequency.hs"
               component: "exe:WordFrequency"
+            - path: "./examples/BytePairEncoder.hs"
+              component: "exe:BytePairEncoder"
 
 dependencies:
   - streamly-examples.cabal

--- a/streamly-examples.cabal
+++ b/streamly-examples.cabal
@@ -354,3 +354,12 @@ executable LogParser
     build-depends: tasty-bench >= 0.3 && < 0.4
   else
     buildable: False
+
+executable BytePairEncoder
+  import: exe-options
+  main-is: BytePairEncoder.hs
+  ghc-options: -main-is BytePairEncoder
+  if !impl(ghcjs)
+    buildable: True
+  else
+    buildable: False


### PR DESCRIPTION
A greedy tokenizer breaks text into words based on data driven rules it has learnt. The learning phase finds the most common pair of tokens in the data and merges them into a new token.

This is a pure text processing application which can be re-imagined as a streaming application, a study of all three fundamental constructs of streaming - Streams, Folds and Pipes and a demonstration of the streamly framework.

A review is welcome.